### PR TITLE
Separate Vessel entity to match API

### DIFF
--- a/jit-application/src/test/java/org/dcsa/jit/datafactories/OperationsEventTODataFactory.java
+++ b/jit-application/src/test/java/org/dcsa/jit/datafactories/OperationsEventTODataFactory.java
@@ -23,14 +23,13 @@ public class OperationsEventTODataFactory {
             .UNLocationCode("USMIA")
             .build();
 
-    VesselTO vesselTO =
-        VesselTO.builder()
+    TransportCallVesselTO vesselTO =
+        TransportCallVesselTO.builder()
             .vesselIMONumber("9321483")
             .vesselName("Emma Maersk")
             .vesselFlag("DK")
             .vesselOperatorCarrierCode("MSK")
             .vesselOperatorCarrierCodeListProvider(CarrierCodeListProvider.SMDG)
-            .isDummy(false)
             .build();
 
     TransportCallTO transportCallTO =

--- a/jit-persistence/src/main/java/org/dcsa/jit/persistence/repository/VesselRepository.java
+++ b/jit-persistence/src/main/java/org/dcsa/jit/persistence/repository/VesselRepository.java
@@ -1,6 +1,8 @@
 package org.dcsa.jit.persistence.repository;
 
 import org.dcsa.jit.persistence.entity.Vessel;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +11,6 @@ import java.util.UUID;
 public interface VesselRepository extends JpaRepository<Vessel, UUID> {
   // TODO when valid_until is implemented use custom query to only look up validUntil == null
   Optional<Vessel> findByVesselIMONumber(String imoNumber);
+
+  Page<Vessel> findAllByIsDummyIsFalse(Pageable pageable);
 }

--- a/jit-service/src/main/java/org/dcsa/jit/mapping/VesselMapper.java
+++ b/jit-service/src/main/java/org/dcsa/jit/mapping/VesselMapper.java
@@ -1,8 +1,8 @@
 package org.dcsa.jit.mapping;
 
 import org.dcsa.jit.persistence.entity.Vessel;
-import org.dcsa.jit.transferobjects.TimestampVesselTO;
-import org.dcsa.jit.transferobjects.VesselTO;
+import org.dcsa.jit.transferobjects.TransportCallVesselTO;
+import org.dcsa.jit.transferobjects.UISupportVesselTO;
 import org.dcsa.jit.transferobjects.enums.CarrierCodeListProvider;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
@@ -16,21 +16,52 @@ public interface VesselMapper {
     @Mapping(target = "vesselName", source = "name"),
     @Mapping(target = "vesselFlag", source = "flag"),
     @Mapping(target = "vesselCallSignNumber", source = "callSignNumber"),
-    @Mapping(target = "isDummy", constant = "false")
   })
-  VesselTO toTO(Vessel vessel);
+  TransportCallVesselTO toTO(Vessel vessel);
 
   @Mappings(value = {
     @Mapping(target = "name", source = "vesselName"),
     @Mapping(target = "flag", source = "vesselFlag"),
     @Mapping(target = "callSignNumber", source = "vesselCallSignNumber"),
-    @Mapping(target = "isDummy", source = "isDummy", defaultValue = "false")
+    @Mapping(target = "isDummy", constant = "false")
   })
-  Vessel toEntity(VesselTO vesselTO);
+  Vessel toEntity(TransportCallVesselTO transportCallVesselTO);
+
+  @Mappings(value = {
+    @Mapping(target = "name", source = "vesselName"),
+    @Mapping(target = "flag", source = "vesselFlag"),
+    @Mapping(target = "callSignNumber", source = "vesselCallSignNumber"),
+    @Mapping(target = "isDummy", constant = "false")
+  })
+  Vessel toEntity(UISupportVesselTO vesselTO);
+
+  @Mappings(value = {
+    @Mapping(target = "vesselName", source = "name"),
+    @Mapping(target = "vesselFlag", source = "flag"),
+    @Mapping(target = "vesselCallSignNumber", source = "callSignNumber")
+  })
+  UISupportVesselTO toUISupportVesselTO(Vessel vessel);
 
   @AfterMapping
   default void mapVesselOperatorCarrier(
-      Vessel vessel, @MappingTarget VesselTO.VesselTOBuilder vesselTOBuilder) {
+      Vessel vessel, @MappingTarget TransportCallVesselTO.TransportCallVesselTOBuilder vesselTOBuilder) {
+    if (vessel.getVesselOperatorCarrier() == null) {
+      return;
+    }
+    String nMFTACode = vessel.getVesselOperatorCarrier().getNmftaCode();
+    String sMDGCode = vessel.getVesselOperatorCarrier().getSmdgCode();
+    if (sMDGCode != null) {
+      vesselTOBuilder.vesselOperatorCarrierCodeListProvider(CarrierCodeListProvider.SMDG);
+      vesselTOBuilder.vesselOperatorCarrierCode(sMDGCode);
+    } else if (nMFTACode != null) {
+      vesselTOBuilder.vesselOperatorCarrierCodeListProvider(CarrierCodeListProvider.NMFTA);
+      vesselTOBuilder.vesselOperatorCarrierCode(nMFTACode);
+    }
+  }
+
+  @AfterMapping
+  default void mapVesselOperatorCarrier(
+    Vessel vessel, @MappingTarget UISupportVesselTO.UISupportVesselTOBuilder vesselTOBuilder) {
     if (vessel.getVesselOperatorCarrier() == null) {
       return;
     }

--- a/jit-service/src/test/java/org/dcsa/jit/service/mapping/VesselMappingTest.java
+++ b/jit-service/src/test/java/org/dcsa/jit/service/mapping/VesselMappingTest.java
@@ -1,14 +1,14 @@
 package org.dcsa.jit.service.mapping;
 
 import org.dcsa.jit.persistence.entity.Vessel;
-import org.dcsa.jit.transferobjects.VesselTO;
+import org.dcsa.jit.transferobjects.TransportCallVesselTO;
 import org.dcsa.skernel.test.helpers.FieldValidator;
 import org.junit.jupiter.api.Test;
 
 public class VesselMappingTest {
   @Test
   public void testTargetFieldsPresentInSrc() {
-    FieldValidator.assertTargetFieldsPresentInSrc(Vessel.class, VesselTO.class,
+    FieldValidator.assertTargetFieldsPresentInSrc(Vessel.class, TransportCallVesselTO.class,
       // special mappings
       "vesselDraft",
       "vesselCallSignNumber",

--- a/jit-transfer-obj/src/main/java/org/dcsa/jit/transferobjects/TransportCallTO.java
+++ b/jit-transfer-obj/src/main/java/org/dcsa/jit/transferobjects/TransportCallTO.java
@@ -23,7 +23,7 @@ public record TransportCallTO(
   @Deprecated @Size(max = 50) String otherFacility, // Deprecated in JIT 1.2
   @NotNull ModeOfTransport modeOfTransport,
   LocationTO location,
-  VesselTO vessel,
+  TransportCallVesselTO vessel,
   @Size(max = 50) String portVisitReference
 ) {
   @Builder(toBuilder = true) // workaround for intellij issue

--- a/jit-transfer-obj/src/main/java/org/dcsa/jit/transferobjects/TransportCallVesselTO.java
+++ b/jit-transfer-obj/src/main/java/org/dcsa/jit/transferobjects/TransportCallVesselTO.java
@@ -9,20 +9,14 @@ import org.dcsa.skernel.infrastructure.validation.ValidVesselIMONumber;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-public record VesselTO(
+public record TransportCallVesselTO(
   @NotNull @ValidVesselIMONumber String vesselIMONumber,
   @Size(max = 35) String vesselName,
   @Size(max = 2) String vesselFlag,
   @Size(max = 10) String vesselCallSignNumber,
   @Size(max = 10) String vesselOperatorCarrierCode,
-  CarrierCodeListProvider vesselOperatorCarrierCodeListProvider,
-  Boolean isDummy,
-  Float length,
-  Float width,
-  VesselType type,
-  DimensionUnit dimensionUnit,
-  Float vesselDraft
+  CarrierCodeListProvider vesselOperatorCarrierCodeListProvider
 ){
   @Builder(toBuilder = true) // workaround for intellij issue
-  public VesselTO {}
+  public TransportCallVesselTO {}
 }

--- a/jit-transfer-obj/src/main/java/org/dcsa/jit/transferobjects/UISupportVesselTO.java
+++ b/jit-transfer-obj/src/main/java/org/dcsa/jit/transferobjects/UISupportVesselTO.java
@@ -1,0 +1,27 @@
+package org.dcsa.jit.transferobjects;
+
+import lombok.Builder;
+import org.dcsa.jit.transferobjects.enums.CarrierCodeListProvider;
+import org.dcsa.jit.transferobjects.enums.DimensionUnit;
+import org.dcsa.jit.transferobjects.enums.VesselType;
+import org.dcsa.skernel.infrastructure.validation.ValidVesselIMONumber;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public record UISupportVesselTO(
+  @NotNull @ValidVesselIMONumber String vesselIMONumber,
+  @Size(max = 35) String vesselName,
+  @Size(max = 2) String vesselFlag,
+  @Size(max = 10) String vesselCallSignNumber,
+  @Size(max = 10) String vesselOperatorCarrierCode,
+  CarrierCodeListProvider vesselOperatorCarrierCodeListProvider,
+  Float length,
+  Float width,
+  VesselType type,
+  DimensionUnit dimensionUnit,
+  Float vesselDraft
+){
+  @Builder(toBuilder = true) // workaround for intellij issue
+  public UISupportVesselTO {}
+}


### PR DESCRIPTION
With this split, we now have *3* vessel entities in JIT/UI-Support:
  * `TimestampVesselTO` (untouched) which is how the vessel is structured
    in the `TimestampTO` entity and is part of the API.
  * `TransportCallVesselTO` which is how the vessel is structured in the
    `TransportCallTO` and is part of the API.
  * `UISupportVesselTO` which is an unofficial entity specifically used
     by the UI in CRUD operations.  It is modelled after the TC version
     as that is what the UI expects right now.  It will probably need
     additional tweaks in future commits.

Admittedly, the latter would ideally be in DCSA-UI-Support, but the
`VesselMapper` was in JIT and it seemed more important that this was
aligned across all three.

Signed-off-by: Niels Thykier <nt@asseco.dk>